### PR TITLE
VL-1998 -  Using mysql driver for pentaho service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ allprojects  {
             dependency 'com.google.truth.extensions:truth-java8-extension:1.1.3'
             dependency 'org.apache.commons:commons-email:1.5'
             dependency 'commons-io:commons-io:2.10.0'
-            dependency 'org.drizzle.jdbc:drizzle-jdbc:1.4'
+            dependency 'mysql:mysql-connector-java:8.0.23'
             dependency 'com.github.librepdf:openpdf:1.3.26'
             dependency 'org.mnode.ical4j:ical4j:3.0.28'
             dependency 'org.quartz-scheduler:quartz:2.3.2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,11 +44,11 @@ services:
     depends_on:
       - fineractmysql
     environment:
-      - DRIVERCLASS_NAME=org.drizzle.jdbc.DrizzleDriver
+      - DRIVERCLASS_NAME=com.mysql.cj.jdbc.Driver
       - PROTOCOL=jdbc
-      - SUB_PROTOCOL=mysql:thin
-      - fineract_tenants_driver=org.drizzle.jdbc.DrizzleDriver
-      - fineract_tenants_url=jdbc:mysql:thin://fineractmysql:3306/fineract_tenants
+      - SUB_PROTOCOL=mysql
+      - fineract_tenants_driver=com.mysql.cj.jdbc.Driver
+      - fineract_tenants_url=jdbc:mysql://fineractmysql:3306/fineract_tenants
       - fineract_tenants_uid=root
       - fineract_tenants_pwd=skdcnwauicn2ucnaecasdsajdnizucawencascdca
       - FINERACT_DEFAULT_TENANTDB_HOSTNAME=fineractmysql

--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -213,7 +213,7 @@ configurations {
     driver
 }
 dependencies {
-    driver 'org.drizzle.jdbc:drizzle-jdbc:1.4'
+    driver 'mysql:mysql-connector-java:8.0.23'
 }
 
 URLClassLoader loader = GroovyObject.class.classLoader
@@ -224,7 +224,7 @@ configurations.driver.each {File file ->
 task createDB {
     description= "Creates the Database. Needs database name to be passed (like: -PdbName=someDBname)"
     doLast {
-        def sql = Sql.newInstance( 'jdbc:mysql:thin://localhost:3306/', mysqlUser, mysqlPassword, 'org.drizzle.jdbc.DrizzleDriver' )
+        def sql = Sql.newInstance( 'jdbc:mysql://localhost:3306/', mysqlUser, mysqlPassword, 'com.mysql.cj.jdbc.Driver' )
         sql.execute( 'create database '+"`$dbName`" )
     }
 }
@@ -232,13 +232,13 @@ task createDB {
 task dropDB {
     description= "Drops the specified database. The database name has to be passed (like: -PdbName=someDBname)"
     doLast {
-        def sql = Sql.newInstance( 'jdbc:mysql:thin://localhost:3306/', mysqlUser, mysqlPassword, 'org.drizzle.jdbc.DrizzleDriver' )
+        def sql = Sql.newInstance( 'jdbc:mysql://localhost:3306/', mysqlUser, mysqlPassword, 'com.mysql.cj.jdbc.Driver' )
         sql.execute( 'DROP DATABASE '+"`$dbName`")
     }
 }
 task setBlankPassword {
     doLast {
-        def sql = Sql.newInstance( 'jdbc:mysql:thin://localhost:3306/', mysqlUser, mysqlPassword, 'org.drizzle.jdbc.DrizzleDriver' )
+        def sql = Sql.newInstance( 'jdbc:mysql://localhost:3306/', mysqlUser, mysqlPassword, 'com.mysql.cj.jdbc.Driver' )
         sql.execute('USE `fineract_tenants`')
         sql.execute('UPDATE fineract_tenants.tenants SET schema_server = \'localhost\', schema_server_port = \'3306\', schema_username = \'mifos\', schema_password = \'mysql\' WHERE id=1;')
     }

--- a/fineract-provider/dependencies.gradle
+++ b/fineract-provider/dependencies.gradle
@@ -67,7 +67,7 @@ dependencies {
             'org.apache.poi:poi-ooxml-schemas:3.15',
             'org.apache.tika:tika-core',
 
-            'org.drizzle.jdbc:drizzle-jdbc',
+            'mysql:mysql-connector-java',
             'org.flywaydb:flyway-core',
 
             'com.github.librepdf:openpdf',

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/report/service/PentahoReportingProcessServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/report/service/PentahoReportingProcessServiceImpl.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.ApiParameterHelper;
+import org.apache.fineract.infrastructure.core.boot.JDBCDriverConfig;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenant;
 import org.apache.fineract.infrastructure.core.domain.FineractPlatformTenantConnection;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
@@ -78,6 +79,9 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
 
     @Autowired
     private Environment env;
+
+    @Autowired
+    private JDBCDriverConfig driverConfig;
 
     @Autowired
     public PentahoReportingProcessServiceImpl(final PlatformSecurityContext context,
@@ -210,8 +214,10 @@ public class PentahoReportingProcessServiceImpl implements ReportingProcessServi
             final FineractPlatformTenant tenant = ThreadLocalContextUtil.getTenant();
             final FineractPlatformTenantConnection tenantConnection = tenant.getConnection();
 
-            String tenantUrl = "jdbc:mysql:thin://" + tenantConnection.getSchemaServer() + ":" + tenantConnection.getSchemaServerPort()
-                    + "/" + tenantConnection.getSchemaName();
+            // setting tenant url using properties instead of hard code values
+            String tenantUrl = this.driverConfig.constructProtocol(tenantConnection.getSchemaServer(),
+                    tenantConnection.getSchemaServerPort(), tenantConnection.getSchemaName(),
+                    tenantConnection.getSchemaConnectionParameters());
 
             rptParamValues.put("username", tenantConnection.getSchemaUsername());
             rptParamValues.put("password", tenantConnection.getSchemaPassword());

--- a/fineract-provider/src/main/resources/META-INF/spring/jdbc.properties
+++ b/fineract-provider/src/main/resources/META-INF/spring/jdbc.properties
@@ -17,11 +17,11 @@
 # under the License.
 #
 
-DRIVERCLASS_NAME:org.drizzle.jdbc.DrizzleDriver
+DRIVERCLASS_NAME:com.mysql.cj.jdbc.Driver
 PROTOCOL:jdbc
-SUB_PROTOCOL:mysql:thin
+SUB_PROTOCOL:mysql
 
-fineract_tenants_driver:org.drizzle.jdbc.DrizzleDriver
-fineract_tenants_url:jdbc:mysql:thin://localhost:3306/fineract_tenants
+fineract_tenants_driver:com.mysql.cj.jdbc.Driver
+fineract_tenants_url:jdbc:mysql://localhost:3306/fineract_tenants
 fineract_tenants_uid:root
 fineract_tenants_pwd:mysql

--- a/kubernetes/fineract-server-deployment.yml
+++ b/kubernetes/fineract-server-deployment.yml
@@ -82,15 +82,15 @@ spec:
           periodSeconds: 1
         env:
         - name: DRIVERCLASS_NAME
-          value: org.drizzle.jdbc.DrizzleDriver
+          value: com.mysql.cj.jdbc.Driver
         - name: PROTOCOL
           value: jdbc
         - name: SUB_PROTOCOL
-          value: mysql:thin
+          value: mysql
         - name: fineract_tenants_driver
-          value: org.drizzle.jdbc.DrizzleDriver
+          value: com.mysql.cj.jdbc.Driver
         - name: fineract_tenants_url
-          value: jdbc:mysql:thin://fineractmysql:3306/fineract_tenants
+          value: jdbc:mysql://fineractmysql:3306/fineract_tenants
         - name: fineract_tenants_uid
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
https://velocitycareerlabs.atlassian.net/browse/VL-1998 

## Description

- Pentaho Service was using Drizzle driver and because of that few reports are not working. 
- Changing Pentaho Service to use mysql jdbc driver which is even use for Velocity upper environment.
- Changing local development environment also to use mysql jdbc driver instead of drizzle.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/api-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
